### PR TITLE
update beancount_parser_2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,9 +104,9 @@ dependencies = [
 
 [[package]]
 name = "beancount_parser_2"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31d0d368739352346fe143541bb590c6d5786613bcdef925c314463c11aaae51"
+checksum = "93ad9423ce1ffc55ccf2f19b2d6242f158c783d356a4fef78cbb6e7bedf79ef7"
 dependencies = [
  "nom",
  "nom_locate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "*"
-beancount_parser_2 = '^1.0.0-beta.2'
+beancount_parser_2 = '=1.0.0-beta.3'
 clap = { version = "4.3.4", features = ["derive"] }
 itertools = "*"
 rust_decimal = "*"

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,5 +1,5 @@
-use beancount_parser_2 as parser;
 use crate::types::*;
+use beancount_parser_2 as parser;
 
 pub fn parse(content: &str) -> anyhow::Result<BeancountFile<rust_decimal::Decimal>> {
     let beancount = match parser::parse::<rust_decimal::Decimal>(content) {
@@ -9,41 +9,41 @@ pub fn parse(content: &str) -> anyhow::Result<BeancountFile<rust_decimal::Decima
     Ok(beancount.into())
 }
 
-impl<D> From<parser::BeancountFile<'_, D>> for BeancountFile<D> {
-    fn from(f: parser::BeancountFile<'_, D>) -> Self {
+impl<D> From<parser::BeancountFile<D>> for BeancountFile<D> {
+    fn from(f: parser::BeancountFile<D>) -> Self {
         BeancountFile {
             directives: f.directives.into_iter().map(|d| d.into()).collect(),
         }
     }
 }
 
-impl<D> From<parser::Directive<'_, D>> for Directive<D> {
-    fn from(d: parser::Directive<'_, D>) -> Self {
+impl<D> From<parser::Directive<D>> for Directive<D> {
+    fn from(d: parser::Directive<D>) -> Self {
         Directive {
             date: d.date,
             content: d.content.into(),
             metadata: d
                 .metadata
                 .into_iter()
-                .map(|(key, value)| (key.to_owned(), value.into()))
+                .map(|(key, value)| (key.to_string(), value.into()))
                 .collect(),
         }
     }
 }
 
-impl<D> From<parser::MetadataValue<D>> for MetadataValue<D> {
-    fn from(v: parser::MetadataValue<D>) -> Self {
+impl<D> From<parser::metadata::Value<D>> for MetadataValue<D> {
+    fn from(v: parser::metadata::Value<D>) -> Self {
         match v {
-            parser::MetadataValue::String(x) => MetadataValue::String(x.to_owned()),
-            parser::MetadataValue::Number(x) => MetadataValue::Number(x),
-            parser::MetadataValue::Currency(x) => MetadataValue::Currency(x.into()),
+            parser::metadata::Value::String(x) => MetadataValue::String(x.to_owned()),
+            parser::metadata::Value::Number(x) => MetadataValue::Number(x),
+            parser::metadata::Value::Currency(x) => MetadataValue::Currency(x.into()),
             _ => unimplemented!("given metadata value type is not supported yet"),
         }
     }
 }
 
-impl<D> From<parser::DirectiveContent<'_, D>> for DirectiveContent<D> {
-    fn from(v: parser::DirectiveContent<'_, D>) -> Self {
+impl<D> From<parser::DirectiveContent<D>> for DirectiveContent<D> {
+    fn from(v: parser::DirectiveContent<D>) -> Self {
         match v {
             parser::DirectiveContent::Balance(x) => DirectiveContent::Balance(x.into()),
             parser::DirectiveContent::Close(x) => DirectiveContent::Close(x.into()),
@@ -75,8 +75,8 @@ impl From<parser::Open> for Open {
     }
 }
 
-impl From<parser::Event<'_>> for Event {
-    fn from(v: parser::Event<'_>) -> Self {
+impl From<parser::Event> for Event {
+    fn from(v: parser::Event) -> Self {
         Self {
             name: v.name.to_owned(),
             value: v.value.to_owned(),
@@ -116,21 +116,21 @@ impl<D> From<parser::Balance<D>> for Balance<D> {
     }
 }
 
-impl<D> From<parser::Transaction<'_, D>> for Transaction<D> {
-    fn from(v: parser::Transaction<'_, D>) -> Self {
+impl<D> From<parser::Transaction<D>> for Transaction<D> {
+    fn from(v: parser::Transaction<D>) -> Self {
         Self {
             flag: v.flag,
             payee: v.payee.map(String::from),
             narration: v.narration.map(String::from),
-            tags: v.tags.into_iter().map(|x| x.into()).collect(),
-            links: v.links.into_iter().map(|x| x.into()).collect(),
+            tags: v.tags.into_iter().map(|x| x.to_string()).collect(),
+            links: v.links.into_iter().map(|x| x.to_string()).collect(),
             postings: v.postings.into_iter().map(|x| x.into()).collect(),
         }
     }
 }
 
-impl<D> From<parser::Posting<'_, D>> for Posting<D> {
-    fn from(v: parser::Posting<'_, D>) -> Self {
+impl<D> From<parser::Posting<D>> for Posting<D> {
+    fn from(v: parser::Posting<D>) -> Self {
         Self {
             flag: v.flag,
             account: v.account.into(),
@@ -140,7 +140,7 @@ impl<D> From<parser::Posting<'_, D>> for Posting<D> {
             metadata: v
                 .metadata
                 .into_iter()
-                .map(|(key, value)| (key.to_owned(), value.into()))
+                .map(|(key, value)| (key.to_string(), value.into()))
                 .collect(),
         }
     }


### PR DESCRIPTION
Hi, 

Sorry for making breaking changes in `beancount_parser_2`. Here's my contribution to updating your work,  hopefully alleviating your pain of depending on my unstable crate.


Thanks for trying out `beancount_parser_2` and making those experiments public :-)

P.S: You should pin the version when you are using the pre-release of a crate (e.g. `=1.0.0-beta.3`), because a pre-release bump may contain breaking changes from a server perspective, but cargo treats all pre-release as if they didn't contain breaking changes.