### PR TITLE
migrate to `beancount-parser` version 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,7 @@ name = "bean"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "beancount_parser_2",
+ "beancount-parser",
  "chrono",
  "clap",
  "itertools",
@@ -131,10 +131,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "beancount_parser_2"
-version = "1.0.0-beta.3"
+name = "beancount-parser"
+version = "2.0.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ad9423ce1ffc55ccf2f19b2d6242f158c783d356a4fef78cbb6e7bedf79ef7"
+checksum = "7d122349b6b09ba17834f6f46557fa962b7fe216df18c741d9a4683886a37321"
 dependencies = [
  "nom",
  "nom_locate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.0"
-beancount_parser_2 = '=1.0.0-beta.3'
+beancount-parser = '=2.0.0-beta.1'
 chrono = "0.4.0"
 clap = { version = "4.3.4", features = ["derive"] }
 itertools = "0.10.0"

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use beancount_parser_2 as parser;
+use beancount_parser as parser;
 
 pub fn parse(content: &str) -> anyhow::Result<BeancountFile<rust_decimal::Decimal>> {
     let beancount = match parser::parse::<rust_decimal::Decimal>(content) {


### PR DESCRIPTION
I finally changed my mind and re-published `beancount_parser_2` under the name of [`beancount-parser`](https://github.com/jcornaz/beancount-parser) (version `2.0.0-beta.1`) and I deprecated the old `beancount_parser_2` name.

You can stick with `beancount-parser` (version 2) now.

Sorry for the confusion.